### PR TITLE
Add quotes to $CWD to allow paths with spaces.

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -9,18 +9,18 @@ AZURE_SUBSCRIPTION=${1:'ca-yolasors-demo-test'}
 AZURE_RESOURCE_GROUP='ci-azure-ng-deploy'
 AZURE_STORAGE='ciazurengdeploy'
 CWD=`pwd`
-TEST_FOLDER=$CWD/.e2e-tests
+TEST_FOLDER="$CWD/.e2e-tests"
 
 function cleanup() {
-    cd $CWD
-    rm -rf $TEST_FOLDER
+    cd "$CWD"
+    rm -rf "$TEST_FOLDER"
 }
 
 # Cleanup test folder in case of error
 trap cleanup ERR
 
-mkdir -p $TEST_FOLDER
-cd $TEST_FOLDER
+mkdir -p "$TEST_FOLDER"
+cd "$TEST_FOLDER"
 
 echo
 echo -------------------------------------------------------------------------------
@@ -37,8 +37,8 @@ npm i -D ../azure-ng-deploy*.tgz
 ng add @azure/ng-deploy -m true -n $AZURE_SUBSCRIPTION -g $AZURE_RESOURCE_GROUP -a $AZURE_STORAGE -l "westus" --telemetry false
 ng build --prod
 ng run sample-app:deploy
-cd $CWD
-rm -rf $TEST_FOLDER
+cd "$CWD"
+rm -rf "$TEST_FOLDER"
 
 # Cleanup resource group using az cli
 az.cmd group delete -n $AZURE_RESOURCE_GROUP -y


### PR DESCRIPTION
Fixes #48

## Description

Added quotes when using the current path in the script.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How to Test

1. Create a directory which has a space in its name, i.e. `my projects`
2. Clone this project into this directory
3. Run `npm i`
4. Run `npm run test:e2e`

## Closing issues

closes #48