### PR TITLE
fix: fixing lowercase and max account name to adhere to Azure rules

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/ng-deploy",
-  "version": "0.1.0-beta.4",
+  "version": "0.1.2",
   "main": "out/ng-add/index.js",
   "files": [
     "out/",

--- a/src/util/azure/account.ts
+++ b/src/util/azure/account.ts
@@ -51,7 +51,13 @@ export async function getAccount(
 
   function getInitialAccountName() {
     const normalizedProjectNameArray = options.project.match(/[a-zA-Z0-9]/g);
-    const normalizedProjectName = normalizedProjectNameArray ? normalizedProjectNameArray.join('') : '';
+    let normalizedProjectName = normalizedProjectNameArray ? normalizedProjectNameArray.join('') : '';
+    
+    /* 
+    ensures project name + 'static' does not overshoot 24 characters (which is the Azure requirement on an account name)
+    additionally it needs to be lowercase (in case we have Angular project like e.g `ExampleApp`)
+    */
+    normalizedProjectName = normalizedProjectName.toLowerCase().substring(0, 18);
     return `${normalizedProjectName}static`;
   }
 


### PR DESCRIPTION
# Pull Request Template

## Description

account name must be:
- lowercase
- max 24 chars (we add the word `static` at the end so that gives us a maximum of 18 characters)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How to Test

- create an Angular project with either a very long name or call it `ExampleApp`, should break

## Closing issues

closes #61 

## Assignee

Please add yourself as the assignee

## Projects

Please add relevant projects so this issue can be properly tracked.
