### PR TITLE
fix: crash when using saved credentials

### DIFF
--- a/src/util/azure/auth.ts
+++ b/src/util/azure/auth.ts
@@ -132,7 +132,5 @@ export async function loginToAzureWithCI(logger: Logger): Promise<AuthResponse> 
 
   auth = await loginWithServicePrincipalSecretWithAuthResponse(CLIENT_ID, CLIENT_SECRET, TENANT_ID);
 
-  globalConfig.set(AUTH, auth);
-
   return auth;
 }

--- a/src/util/azure/auth.ts
+++ b/src/util/azure/auth.ts
@@ -73,6 +73,7 @@ export async function loginToAzure(logger: Logger): Promise<AuthResponse> {
       const cache = new MemoryCache();
       cache.add(creds.tokenCache._entries, () => {});
 
+      // we need to regenerate a proper object from the saved credentials
       auth.credentials = new DeviceTokenCredentials(
         clientId,
         domain,
@@ -82,8 +83,8 @@ export async function loginToAzure(logger: Logger): Promise<AuthResponse> {
         cache
       );
 
-      const token = await creds.getToken();
-      // if extracted token has expiredm, we request a new login flow
+      const token = await auth.credentials.getToken();
+      // if extracted token has expired, we request a new login flow
       if (new Date(token.expiresOn).getTime() < Date.now()) {
         logger.info(`Your stored credentials have expired; you'll have to log in again`);
 


### PR DESCRIPTION
# Pull Request Template

## Description

Fix crash with `creds.getToken` error when you have saved credentials.

I also removed saving the credentials in CI mode, because that's a different kind of credentials object, ie `ApplicationTokenCredentials` vs `DeviceTokenCredentials` so loading this kind of credentials from cache won't work for now.
I suggest we use proper adapters for saving/loading credentials to avoid this kind of issues in the future, if we plan to support other auth methods.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

