### PR TITLE
Telemetry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -336,6 +336,7 @@ src/**/*.js
 src/**/*.js.map
 src/**/*.d.ts
 lib/**/*
+*.tgz
 
 # IDEs
 .idea/
@@ -344,6 +345,8 @@ jsconfig.json
 
 # Misc
 node_modules/
+environments/*
+!environments/environment.dev.json
 npm-debug.log*
 yarn-error.log*
 package-lock.json

--- a/.gitignore
+++ b/.gitignore
@@ -348,6 +348,7 @@ npm-debug.log*
 yarn-error.log*
 package-lock.json
 yarn.lock
+.env
 
 # Mac OSX Finder files.
 **/.DS_Store

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,6 +80,30 @@ Testing is done with [Jest](https://jestjs.io/). To run the tests:
 npm run test:jest
 ```
 
+### Environments
+
+You can manage different environments by creating JSON files and setting the `NODE_ENV` variable accordingly.
+The default environment is `dev`, which uses the file `environments/environment.dev.json`.
+
+1. Create a JSON file under the folder `environments` with the name `environment.<environment name>.json`,
+   for example: `environment.prod.json`
+2. Add your variables to the JSON object within the file.
+3. Require the file `environment.json` (without the environment name) wherever needed, relatively to the `src` folder.
+   For example, in `src/ng-add/index.ts` use:
+
+```ts
+const environment = require('../environments/environment.json');
+```
+
+4. Set the `NODE_ENV` environment variable with the environment name before running `build` or `start`.
+   The default value is `dev`. For example:
+
+```sh
+NODE_ENV=prod npm run build
+```
+
+## Submitting Pull Requests <a name="submitting-prs"></a>
+
 When you submit a pull request, a CLA-bot will automatically determine whether you need
 to provide a CLA and decorate the PR appropriately (e.g., label, comment). Simply follow the
 instructions provided by the bot. You will only need to do this once across all repositories using our CLA.

--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@
 
 ## Quick-start <a name="quickstart"></a>
 
-1. Install the next version of the Angular CLI (v8.0.0-beta.18 or greater) and create a new Angular project.
+1. Install the next version of the Angular CLI (v8.3.0 or greater) and create a new Angular project.
 
    ```sh
-   npm install -g @angular/cli@next
+   npm install -g @angular/cli
    ng new hello-world --defaults
    cd hello-world
    ```
@@ -23,24 +23,20 @@
 1. Add `ng-deploy` to your project and create your Azure blob storage resources.
 
    ```sh
-   ng add @azure/ng-deploy@beta
+   ng add @azure/ng-deploy
    ```
 
-1. You may be prompted you to sign in to Azure, providing a link to open in your browser and a code to paste in the login page.
-
-1. Build your Angular app.
-
-   ```sh
-   ng build --prod
-   ```
+   You may be prompted you to sign in to Azure, providing a link to open in your browser and a code to paste in the login page.
 
 1. Deploy your project to Azure.
 
    ```sh
-   ng run hello-world:deploy
+   ng deploy
    ```
 
-You will see output similar to the following. Browse to the link and view your site running in Azure blob storage!
+   The project will be built in production mode and deployed to the storage account configured in the previous step.
+
+   You will see output similar to the following. Browse to the link and view your site running in Azure blob storage!
 
 ```sh
 see your deployed site at https://helloworldstatic52.z22.web.core.windows.net/
@@ -56,15 +52,13 @@ If you don't have an Azure subscription, [create your Azure free account from th
 
 ### Angular CLI <a name="angular-cli"></a>
 
-1. Install the next version of the Angular CLI (v8.0.0-beta.18 or greater).
+1. Install the next version of the Angular CLI (v8.3.0 or greater).
 
    ```sh
-   npm install -g @angular/cli@next
+   npm install -g @angular/cli@latest
    ```
 
-   > As long as version 8 is in RC, use `@next` instead of `@latest`
-
-1. Run `ng --version`, make sure you have angular CLI version v8.0.0-beta.18 or greater.
+1. Run `ng --version`, make sure you have angular CLI version v8.3.0 or greater.
 
 1. If need instructions to update the CLI, [follow these upgrade instructions](https://www.npmjs.com/package/@angular/cli#updating-angular-cli).
 
@@ -104,12 +98,12 @@ The command will create the file `azure.json` with the deployment configuration 
 
 _Note: at the moment, the command will fail if an `azure.json` file already exists. Please remove the file before running the command._
 
-### deploy <a name="deploy"></a>
+### Deploy <a name="deploy"></a>
 
 You can deploy your application to the selected storage account by running the following command.
 
 ```sh
-ng run <project-name>:deploy
+ng deploy
 ```
 
 If the build target (`dist/<project-name>` folder) is empty, the project will be built with the production option (similar to running `ng build --prod`).
@@ -124,7 +118,7 @@ To clear the cached credentials run:
 ng run <project-name>:azureLogout
 ```
 
-This command is available only after signing in to Azure.
+This command is available only after completing `ng add @azure/ng-deploy`.
 
 ## Data/Telemetry <a name="telemetry"></a>
 
@@ -135,14 +129,16 @@ Read Microsoft's [privacy statement](https://privacy.microsoft.com/en-gb/privacy
 To turn off telemetry, add the telemetry flag (`--telemetry` or `-t`) with the `false` value when running `ng add`, like this:
 
 ```sh
-ng add ng-deploy-azure --telemetry=false
+ng add @azure/ng-deploy --telemetry=false
 ```
 
 or
 
 ```sh
-ng add ng-deploy-azure -t=false
+ng add @azure/ng-deploy -t=false
 ```
+
+The configuration will be saved and applied when running `ng deploy`.
 
 ### Additional options <a name="options"></a>
 
@@ -213,5 +209,4 @@ Please refer to [CONTRIBUTING](CONTRIBUTING.md) for CLA guidance.
 
 - Learn more about Azure Static Hosting in this [blog post announcing Static websites on Azure Storage](https://azure.microsoft.com/en-us/blog/static-websites-on-azure-storage-now-generally-available/?WT.mc_id=ng_deploy_azure-github-cxa)
 - Install this [VS Code extension for Azure Storage](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-azurestorage&WT.mc_id=ng_deploy_azure-github-cxa)
-- # Follow this tutorial to [deploy a static website to Azure](https://code.visualstudio.com/tutorials/static-website/getting-started?WT.mc_id=ng_deploy_azure-github-cxa)
-- [John Papa](https://github.com/johnpapa) for guiding through and supporting the development, publish and release.
+- Follow this tutorial to [deploy a static website to Azure](https://code.visualstudio.com/tutorials/static-website/getting-started?WT.mc_id=ng_deploy_azure-github-cxa)

--- a/environments/environment.dev.json
+++ b/environments/environment.dev.json
@@ -1,0 +1,3 @@
+{
+  "production": false
+}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
   ],
   "description": "@azure/ng-deploy - Deploy Angular apps to Azure using the Angular CLI",
   "scripts": {
-    "build": "tsc -p tsconfig.json && npm run copy:builders:json && npm run copy:ngadd:json && tsc -p tsconfig.json",
+    "getenv": "mkdir -p out/environments && cp ./environments/environment.${NODE_ENV:-dev}.json ./out/environments/environment.json",
+    "copy": "npm run copy:builders:json && npm run copy:ngadd:json",
+    "build": "tsc -p tsconfig.json && npm run getenv && npm run copy && tsc -p tsconfig.json",
     "start": "npm run build:watch",
     "build:watch": "npm run build -s -- -w",
     "format": "npm run format:check -s -- --write",
@@ -69,6 +71,7 @@
     "@azure/ms-rest-nodeauth": "^0.8.3",
     "@azure/storage-blob": "^10.3.0",
     "adal-node": "^0.1.28",
+    "applicationinsights": "^1.4.1",
     "chalk": "^2.4.2",
     "conf": "^3.0.0",
     "fuzzy": "^0.1.3",
@@ -78,8 +81,7 @@
     "mime-types": "^2.1.21",
     "ora": "^3.4.0",
     "progress": "^2.0.3",
-    "promise-limit": "^2.7.0",
-    "typescript": "~3.4.0"
+    "promise-limit": "^2.7.0"
   },
   "devDependencies": {
     "@schematics/angular": "^8.2.0",

--- a/src/builders/deploy.builder.ts
+++ b/src/builders/deploy.builder.ts
@@ -9,9 +9,16 @@ import { join } from 'path';
 import { readFileSync } from 'fs';
 import { AzureHostingConfig, AzureJSON } from '../util/workspace/azure-json';
 import deploy from './actions/deploy';
+import { startInsights } from '../util/azure/app-insights';
+
+const environment = require('../environments/environment.json');
 
 export default createBuilder<any>(
   async (builderConfig: any, context: BuilderContext): Promise<BuilderOutput> => {
+    if (builderConfig.telemetry) {
+      startInsights(environment.insightsKey, environment.production);
+    }
+
     const root = normalize(context.workspaceRoot);
     const workspace = new experimental.workspace.Workspace(root, new NodeJsSyncHost());
     await workspace.loadWorkspaceFromHost(normalize('angular.json')).toPromise();

--- a/src/ng-add/index.ts
+++ b/src/ng-add/index.ts
@@ -12,8 +12,15 @@ import { getAccount, getAzureStorageClient } from '../util/azure/account';
 import { AngularWorkspace } from '../util/workspace/angular-json';
 import { generateAzureJson, readAzureJson, getAzureHostingConfig } from '../util/workspace/azure-json';
 import { AddOptions } from '../util/shared/types';
+import { startInsights } from '../util/azure/app-insights';
+
+const environment = require('../environments/environment.json');
 
 export function ngAdd(_options: AddOptions): Rule {
+  if (_options.telemetry) {
+    startInsights(environment.insightsKey, environment.production);
+  }
+
   return (tree: Tree, _context: SchematicContext) => {
     return chain([addDeployAzure(_options)])(tree, _context);
   };

--- a/src/util/azure/app-insights.ts
+++ b/src/util/azure/app-insights.ts
@@ -1,0 +1,15 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+export function startInsights(insightsKey: string, isProd = false) {
+  const appInsights = require('applicationinsights');
+  if (!insightsKey) {
+    if (isProd) {
+      console.error('App Insights key is missing');
+    }
+    return;
+  }
+  appInsights.setup(insightsKey);
+  appInsights.start();
+}

--- a/src/util/workspace/angular-json.ts
+++ b/src/util/workspace/angular-json.ts
@@ -17,6 +17,7 @@ export class AngularWorkspace {
   target: string;
   configuration: string;
   path: string;
+  telemetry: boolean;
 
   constructor(tree: Tree, options: any) {
     this.tree = tree;
@@ -30,6 +31,7 @@ export class AngularWorkspace {
     this.path = this.project.architect
       ? this.project.architect[this.target].options.outputPath
       : `dist/${this.projectName}`;
+    this.telemetry = !(options.telemetry === false);
   }
 
   getPath() {
@@ -121,7 +123,8 @@ export class AngularWorkspace {
       options: {
         host: 'Azure',
         type: 'static',
-        config: 'azure.json'
+        config: 'azure.json',
+        telemetry: this.telemetry
       }
     };
 


### PR DESCRIPTION
# Pull Request - App Insights

## Description

Added Azure ApplicationInsights SDK, collecting default telemetry.
Saving the user's choice whether to allow telemetry.
Introducing environment JSONs.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How to Test

Open an Application Insights service on Azure.
Add its Instrumentation Key to `environment.dev.json` or `environment.test.json` as `"insightsKey"`.
Test the app regularly (`ng add` and `ng deploy`). Check whether the http requests were recorded in the App Insights.
Make sure it's recorded when not using the telemetry flag, or when using it with `true`, and not when using it with `false`. The choice of telemetry should be added to `angular.json` under the `deploy` section.

## Closing issues

Closes #32 
