### PR TITLE
fix: save package in devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,9 @@
   "license": "MIT",
   "builders": "./builders.json",
   "schematics": "./collection.json",
+  "ng-add": {
+    "save": "devDependencies"
+  },
   "dependencies": {
     "@angular-devkit/architect": "^0.801.2",
     "@angular-devkit/core": "^8.0.1",


### PR DESCRIPTION
In the latest versions of the CLI `ng-add` packages can be added to `devDependencies` and this package is perfect for such use case since it's only needed for development.

See: https://github.com/angular/angular-cli/pull/15815

# Pull Request Template

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How to Test

- Replace this with instructions on how to test this PR

## Closing issues

Put closes #XXXX in your comment to auto-close the issue that your PR fixes (if such).

## Assignee

Please add yourself as the assignee

## Projects

Please add relevant projects so this issue can be properly tracked.
