### PR TITLE
chore: add release-it + config

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "test:e2e": "./scripts/test.sh",
     "test:coverage": "jest --coverage",
     "copy:builders:json": "cp ./src/builders/*.json ./out/builders",
-    "copy:ngadd:json": "cp ./src/ng-add/*.json ./out/ng-add"
+    "copy:ngadd:json": "cp ./src/ng-add/*.json ./out/ng-add",
+    "release": "release-it"
   },
   "keywords": [
     "schematics",
@@ -90,6 +91,7 @@
   "devDependencies": {
     "@commitlint/cli": "^8.1.0",
     "@commitlint/config-conventional": "^8.1.0",
+    "@release-it/conventional-changelog": "^1.1.0",
     "@schematics/angular": "^8.2.0",
     "@types/conf": "^2.1.0",
     "@types/glob": "^7.1.1",
@@ -104,6 +106,7 @@
     "jest": "^24.8.0",
     "prettier": "^1.18.2",
     "pretty-quick": "^1.11.1",
+    "release-it": "^12.6.1",
     "schematics-utilities": "^1.1.2",
     "ts-jest": "^24.0.2",
     "typescript": "~3.4.0"
@@ -134,6 +137,23 @@
   "config": {
     "commitizen": {
       "path": "cz-conventional-changelog"
+    }
+  },
+  "release-it": {
+    "github": {
+      "release": true
+    },
+    "hooks": {
+      "before:init": [
+        "npm run build",
+        "npm run test"
+      ]
+    },
+    "plugins": {
+      "@release-it/conventional-changelog": {
+        "preset": "angular",
+        "infile": "CHANGELOG.md"
+      }
     }
   }
 }


### PR DESCRIPTION
# Pull Request Template

## Description

Somehow I stumbled upon #22 and wanted to show what [release-it](https://github.com/release-it/release-it) could do for you:

- Auto-determine next version based on convention-based commits
- Generate and update `CHANGELOG.md`
- Git commit/tag/push
- Create GitHub Release
- Publish to npm
- Provide hooks to execute any commands where necessary (see this PR for an example)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How to Test

Run `npm install` to add dependencies and then `npm run release` to see it in action. Make sure to not actually push/publish anything when only test driving.

Let me know if you have any questions or can help! Cheers.