### PR TITLE
fix(ng-add): 'NOT SUPPORTED: keyword "id", use "$id" for schema ID'

### DIFF
--- a/src/ng-add/schema.json
+++ b/src/ng-add/schema.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "http://json-schema.org/schema",
   "$id": "azure-deploy-schematic-ng-add",
   "title": "Azure Deploy ng-add schematic",
   "type": "object",


### PR DESCRIPTION
ng-add/schema.json "$schema" property was causing an error ("NOT SUPPORTED: keyword "id", use "$id" for schema ID") from package "ajv", removed as it was redundant either way

https://github.com/Azure/ng-deploy-azure/issues/106

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## How to Test

Try to replicate the issue from #106 with the original package, then try with this version

## Closing issues

Closes #106 

